### PR TITLE
Add gentle flake8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run tests and checks
 
 on:
   push:
@@ -24,3 +24,18 @@ jobs:
         python -c "from lcapy import show_version; show_version()"
     - name: Run tests
       run: nosetests
+
+  checks:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: pip3 install .[test]
+    - name: Run Flake8
+      run: flake8
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+# Apply a small subset of rules which have a high chance of catching bugs
+select = E112,E113,E9,W6,F402,F404,F406,F407,F5,F6,F7,F821,F823,F831,B,B902,I900
+ignore = E731,W605,F504,F522,F523,F541,F705,B001,B005,B007,B008,B013,B014,B015

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ __version__ = '0.71'
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-tests_require = ['nose']
+tests_require = ['nose', 'flake8', 'flake8-bugbear', 'flake8-comprehensions', 'flake8-requirements']
 
 
 setup(name='lcapy',


### PR DESCRIPTION
I also added some linters with pretty focused rules to your CI. Some of these are probably bugs!

```
./lcapy/laplace.py:323:20: F821 undefined name 'inverse_laplace_damped_sin3'
./lcapy/laplace.py:594:51: F821 undefined name 'expr'
./lcapy/netlist.py:63:17: F402 import 'j' from line 14 shadowed by loop variable
./lcapy/netlist.py:470:41: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/netlist.py:524:33: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/netlist.py:1890:18: B902 Invalid first argument 'cls' used for instance method. Use the canonical first argument name in methods, i.e. self.
./lcapy/system.py:36:9: F402 import 'path' from line 8 shadowed by loop variable
./lcapy/mnacpts.py:86:14: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
./lcapy/sym.py:74:27: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/sym.py:74:57: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/sym.py:148:27: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/sequence.py:224:25: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/sequence.py:224:31: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/phasor.py:73:27: F821 undefined name 'omegaExpr'
./lcapy/ztransform.py:606:87: F821 undefined name 'expr'
./lcapy/ztransform.py:664:87: F821 undefined name 't'
./lcapy/kexpr.py:88:22: F821 undefined name 'nExpr'
./lcapy/super.py:14:1: I900 'six' not listed as a requirement
./lcapy/super.py:110:13: F402 import 'expr' from line 10 shadowed by loop variable
./lcapy/super.py:138:17: F402 import 'expr' from line 10 shadowed by loop variable
./lcapy/zexpr.py:169:36: F821 undefined name 's'
./lcapy/nexpr.py:287:16: F821 undefined name 'Sequence'
./lcapy/network.py:287:23: F821 undefined name 's'
./lcapy/ratfun.py:421:31: F821 undefined name 'demon'
./lcapy/schematic.py:816:21: I900 'IPython.display' not listed as a requirement
./lcapy/schematic.py:830:13: I900 'IPython.display' not listed as a requirement
./lcapy/expr.py:173:33: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./lcapy/expr.py:458:16: B004 Using `hasattr(x, '__call__')` to test if `x` is callable is unreliable. If `x` implements custom `__getattr__` or its `__call__` is itself not callable, you might get misleading results. Use `callable(x)` for consistent results.
./lcapy/printing.py:217:16: F821 undefined name 'tex'
```