### PR TITLE
Fix incompatibility with newer versions of DomainMatrix.inv

### DIFF
--- a/lcapy/config.py
+++ b/lcapy/config.py
@@ -47,12 +47,12 @@ greek_letter_names = ('alpha', 'beta', 'gamma', 'delta', 'epislon',
 
 words = greek_letter_names
 
-# Can be 'GE', 'LU', 'ADJ', 'LDL', 'CH', 'DM-GE', 'DM-LU', 'DM-charpoly'
-# Note, the DM methods require the git version of sympy otherwise
+# Can be 'GE', 'LU', 'ADJ', 'LDL', 'CH', 'DM'
+# Note, the DM method requires a new version of sympy otherwise
 # the fallback method is used.
 try:
     from sympy.polys.domainmatrix import DomainMatrix
-    matrix_inverse_method = 'DM-charpoly'
+    matrix_inverse_method = 'DM'
 except:
     matrix_inverse_method = 'ADJ'
 

--- a/lcapy/matrix.py
+++ b/lcapy/matrix.py
@@ -302,16 +302,16 @@ of size %dx%d""" % (N, N, N))
         except:
             return M.inv(method='GE')
 
-    elif method.startswith('DM-'):
+    elif method == 'DM':
         try:
-            # This is experimental and requires sympy to be built from
-            # git.  It only works for rational function fields but
+            # This is experimental and requires a new version of sympy.
+            # It only works for rational function fields but
             # fails for polynomial rings.  The latter can be handled
             # by converting it to a field, however, we just fall back
             # on a standard method.
             from sympy.polys.domainmatrix import DomainMatrix
             dM = DomainMatrix.from_list_sympy(*M.shape, rows=M.tolist())
-            return dM.inv(method=method[3:]).to_Matrix()
+            return dM.inv().to_Matrix()
         except:
             method = matrix_inverse_fallback_method
 


### PR DESCRIPTION
Newer versions of `sympy.polys.domainmatrix.DomainMatrix.inv()` does not have the keyword argument `method`. This fixes the resulting incompatibility.