### PR TITLE
Replaced nose testing with pytest & coverage to support python >3.10.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+data_file = ./testing/.coverage
+
+[html]
+directory = ./testing/htmlcov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         pip install .[test]
         python -c "from lcapy import show_version; show_version()"
     - name: Run tests
-      run: nosetests
+      run: pytest
 
   checks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           # pdflatex not installed for some reason with 3.6 and 3.7.  FIXME
           - os: windows-2019

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ unit_tests/coverage
 *.egg-info/
 misc/*
 issues/*
+testing/*

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,12 @@ upload: package
 
 .PHONY: test
 test: lcapy/*.py
-	nosetests -s --pdb
+	pytest -s --pdb -o cache_dir=test/.pytest_cache
 
 .PHONY: cover
 cover: lcapy/*.py
-	nosetests --pdb --with-coverage --cover-package=lcapy --cover-html
+	coverage run -m pytest -s --pdb --pyargs lcapy -o cache_dir="./testing/.pytest_cache"
+	coverage html
 
 .PHONY: doc
 release: doc push
@@ -59,5 +60,5 @@ doc:
 
 .PHONY: clean
 clean:
-	-rm -rf build lcapy.egg-info dist
+	-rm -rf build lcapy.egg-info dist testing
 	cd doc; make clean

--- a/doc/internals.rst
+++ b/doc/internals.rst
@@ -307,7 +307,7 @@ Debugging
 
 The Python debugger (pdb) can be invoked when a unit test fails using::
 
-   $ nosetests3 --pdb
+   $ pytest --pdb
    
 
 Expressions

--- a/doc/problems.rst
+++ b/doc/problems.rst
@@ -268,7 +268,7 @@ Expressions have a `debug()` method that prints the representation of the expres
 Testing
 =======
 
-If you fix a problem, please add a test in `lcapy/lcapy/tests`.  These use the nose format, see https://pythontesting.net/framework/nose/nose-introduction/  The tests can be run using:
+If you fix a problem, please add a test in `lcapy/lcapy/tests`.  These use the pytest format, see https://docs.pytest.org  The tests can be run using:
 
 .. code-block:: console
 
@@ -280,7 +280,7 @@ Specific tests can be run using:
 
 .. code-block:: console
 
-    $ nosetests3 --pdb lcapy/tests/test_laplace.py
+    $ pytest --pdb lcapy/tests/test_laplace.py
 
 With the --pdb option, the Python debugger is entered on failure:
 

--- a/lcapy/tests/README
+++ b/lcapy/tests/README
@@ -1,10 +1,8 @@
-These tests scripts are run using nosetests in the root directory of lcapy
-or in the unit_tests directory.
+These tests scripts are run using pytest in the root directory of lcapy
+or in the lcapy/tests directory.
 
 They can be run individually, for example,
 
-nosetests test_circuits.py
-
-For python3 use nosetests3
+pytest test_circuits.py
 
 If a test hangs, run with -v option to display which test is hanging.

--- a/lcapy/tests/test_parser.py
+++ b/lcapy/tests/test_parser.py
@@ -1,115 +1,103 @@
 import lcapy.grammar as grammar
 import lcapy.mnacpts as mnacpts
+import pytest
 from lcapy.parser import Parser
-from nose.tools import *
 import sys
-sys.path.append('..')
 
+sys.path.append('..')
 
 parser = Parser(mnacpts, grammar)
 parse = parser.parse
 
 
-@raises(ValueError)
 def test_Exception1():
-    '''Test missing arg'''
+    """Test missing arg"""
+    with pytest.raises(ValueError):
+        parse('V1 2')
 
-    parse('V1 2')
 
-
-@raises(ValueError)
 def test_Exception2():
-    '''Test too many args'''
+    """Test too many args"""
+    with pytest.raises(ValueError):
+        parse('V1 2 3 4 5 6')
 
-    parse('V1 2 3 4 5 6')
 
-
-@raises(ValueError)
 def test_Exception3():
-    '''Test too many args'''
+    """Test too many args"""
+    with pytest.raises(ValueError):
+        parse('V1 2 3 dc 4 5 6')
 
-    parse('V1 2 3 dc 4 5 6')
 
-
-@raises(ValueError)
 def test_Exception4():
-    '''Test unknown component'''
+    """Test unknown component"""
 
-    parse('B1 1 2')
+    with pytest.raises(ValueError):
+        parse('B1 1 2')
 
 
-@raises(ValueError)
 def test_Exception5():
-    '''Test arg reassignment'''
+    """Test arg reassignment"""
+    with pytest.raises(ValueError):
+        parse('E1 1 2 opamp 3 4 A Ad=10')
 
-    parse('E1 1 2 opamp 3 4 A Ad=10')
 
-
-@raises(ValueError)
 def test_Exception6():
-    '''Test unknown arg'''
-
-    parse('V1 1 2 foo=3')
+    """Test unknown arg"""
+    with pytest.raises(ValueError):
+        parse('V1 1 2 foo=3')
 
 
 def test_V1():
-    '''Test voltage source'''
+    """Test voltage source"""
 
-    assert_equals(type(parse('V1 1 2')), mnacpts.V, 'Class not V')
-    assert_equals(str(parse('V1 1 2')), 'V1 1 2', 'V netmake')
+    assert type(parse('V1 1 2')) == mnacpts.V, 'Class not V'
+    assert str(parse('V1 1 2')) == 'V1 1 2', 'V netmake'
 
 
 def test_Vdc1():
-    '''Test dc voltage source'''
+    """Test dc voltage source"""
 
-    assert_equals(type(parse('V1 1 2 dc')),
-                  mnacpts.classes['Vdc'], 'Class not Vdc')
-    assert_equals(str(parse('V1 1 2 dc')), 'V1 1 2 dc', 'V dc netmake')
+    assert type(parse('V1 1 2 dc')) == mnacpts.classes['Vdc'], 'Class not Vdc'
+    assert str(parse('V1 1 2 dc')) == 'V1 1 2 dc', 'V dc netmake'
 
 
 def test_Vac1():
-    '''Test ac voltage source'''
+    """Test ac voltage source"""
 
-    assert_equals(type(parse('V1 1 2 ac')),
-                  mnacpts.classes['Vac'], 'Class not Vac')
+    assert type(parse('V1 1 2 ac')) == mnacpts.classes['Vac'], 'Class not Vac'
 
 
 def test_Vsin1():
-    '''Test sin voltage source'''
+    """Test sin voltage source"""
 
-    assert_equals(type(parse('V1 1 2 sin(1, 2, 3)')),
-                  mnacpts.classes['Vsin'], 'Class not Vsin')
+    assert type(parse('V1 1 2 sin(1, 2, 3)')) == mnacpts.classes['Vsin'], 'Class not Vsin'
 
 
 def test_Vexpr():
-    '''Test voltage source with expr'''
+    """Test voltage source with expr"""
 
-    assert_equals(type(parse('V1 1 2 {a * 5}')),
-                  mnacpts.V, 'Class not V')
-    assert_equals(str(parse('V1 1 2 {a * 5}')),
-                  'V1 1 2 {a * 5}', 'V expr netmake')
+    assert type(parse('V1 1 2 {a * 5}')) == mnacpts.V, 'Class not V'
+    assert str(parse('V1 1 2 {a * 5}')) == 'V1 1 2 {a * 5}', 'V expr netmake'
 
 
 def test_Vexpr2():
-    '''Test voltage source with expr as name'''
+    """Test voltage source with expr as name"""
 
-    assert_equals(str(parse('V1 1 2 V1')), 'V1 1 2', 'V expr2 netmake')
+    assert str(parse('V1 1 2 V1')) == 'V1 1 2', 'V expr2 netmake'
 
 
 def test_Vac2():
-    '''Test ac voltage source'''
+    """Test ac voltage source"""
 
-    assert_equals(
-        type(parse('V1 1 2 ac {1j} {0} 3')), mnacpts.classes['Vac'], 'Class not Vac')
+    assert type(parse('V1 1 2 ac {1j} {0} 3')) == mnacpts.classes['Vac'], 'Class not Vac'
 
 
 def test_Vquotes():
-    '''Test voltage source with arg in quotes'''
+    """Test voltage source with arg in quotes"""
 
-    assert_equals(type(parse('V1 1 2 "a * 5"')),
-                  mnacpts.V, 'Class not V')
+    assert type(parse('V1 1 2 "a * 5"')) == mnacpts.V, 'Class not V'
 
 # def test_opamp():
 #     '''Test opamp'''
 #
-#     assert_equals(type(parse('E 1 2 opamp 3 4')), mnacpts.classes['Eopamp'], 'Class not Eopamp')
+#     assert type(parse('E 1 2 opamp 3 4')) == mnacpts.classes['Eopamp'], 'Class not Eopamp'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ __version__ = '1.20'
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-tests_require = ['nose', 'flake8', 'flake8-bugbear',
+tests_require = ['pytest', 'flake8', 'flake8-bugbear',
                  'flake8-comprehensions', 'flake8-requirements']
 
 


### PR DESCRIPTION
Replaced nosetests with pytest.
Updated all references to nosetests in documentation with pytest.
Updated github workflow to support python 3.7 to 3.12.