### PR TITLE
Docs: Add required extension and deps to RTD config files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
 python:
   install:
     - method: pip
-      path: .
+      path: .[doc]
 sphinx:
   configuration: doc/conf.py
   fail_on_warning: false

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 #extensions = ['sphinx.ext.autodoc', 'sphinx.ext.imgmath']
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.mathjax', 'sphinx.ext.napoleon',]
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary',
+              'sphinx.ext.mathjax', 'sphinx.ext.napoleon', 'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### Description
This PR is an attempt to reconfigure RTD's build environment so that it can build again.

Readthedocs is currently showing a "latest" build from January 2024 f591197. There's no failed build logs that I can see as  a non-maintainer, but a 0ac21bc added sphinx_rtd_theme as the html theme without adding sphinx_rtd_theme as an extension in docs/conf.py. The .readthedocs.yaml file also installs "." without the [doc] option, so if I understand the build environment, the container which builds the docs for RTD will not have the theme available.

The doc.yml Github Action workflow uses the [doc] option and builds successfully. I'm unable to test the RTD build process without maintainer permissions; please provide the logs if it fails and I can tweak this PR.

### Related Issues
None that I could see.

### Changes Made
This commit adds "sphinx_rtd_theme" to extensions in conf.py, and adds [doc] to the pip install command in .readthedocs.yaml.






