### PR TITLE
fix: amend indentations and missing docstrings that were confusing docutils

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,10 +3,22 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  apt_packages:
+    - texlive-latex-base
+    - texlive-latex-extra
+    - texlive-pictures
+    - cm-super
+    - dvipng
+    - ghostscript
+  jobs:
+    pre_build:
+      - export MPLBACKEND=Agg
+
 python:
   install:
     - method: pip
       path: .[doc]
+
 sphinx:
   configuration: doc/conf.py
   fail_on_warning: false

--- a/lcapy/network.py
+++ b/lcapy/network.py
@@ -217,24 +217,28 @@ class Network(object):
         decimal places used to evaluate floats.
 
         `kwargs` include:
-           label_ids: True to show component ids
-           label_values: True to display component values
-           draw_nodes: True to show all nodes, False to show no nodes,
-             'primary' to show primary nodes,
-             'connections' to show nodes that connect more than two components,
-             'all' to show all nodes
-           label_nodes: True to label all nodes, False to label no nodes,
-             'primary' to label primary nodes,
-             'alpha' to label nodes starting with a letter,
-             'pins' to label nodes that are pins on a chip,
-             'all' to label all nodes
-           style: 'american', 'british', or 'european'
-           scale: schematic scale factor, default 1.0
-           node_spacing: spacing between component nodes, default 2.0
-           cpt_size: size of a component, default 1.5
-           dpi: dots per inch for png files
-           help_lines: distance between lines in grid, default 0.0 (disabled)
-           debug: True to display debug information
+            label_ids: True to show component ids
+            label_values: True to display component values
+            draw_nodes:
+                True: show all nodes
+                False: show no nodes
+                'primary': show primary nodes
+                'connections': show nodes that connect more than two components
+                'all': show all nodes
+            label_nodes:
+                True: label all nodes
+                False: label no nodes
+                'primary': label primary nodes
+                'alpha': label nodes starting with a letter
+                'pins': label nodes that are pins on a chip
+                'all': label all nodes
+            style: 'american', 'british', or 'european'
+            scale: schematic scale factor, default 1.0
+            node_spacing: spacing between component nodes, default 2.0
+            cpt_size: size of a component, default 1.5
+            dpi: dots per inch for png files
+            help_lines: distance between lines in grid, default 0.0 (disabled)
+            debug: True to display debug information
         """
 
         if 'label_ids' not in kwargs:

--- a/lcapy/noiseexpr.py
+++ b/lcapy/noiseexpr.py
@@ -73,6 +73,7 @@ class NoiseExpression(Expr):
         return self.assumptions['nid']
 
     def subs(self, *args, **kwargs):
+        """Substitute values into the noise expression."""
         nid = self.nid
         result = super(NoiseExpression, self).subs(*args, **kwargs)
         result.assumptions['nid'] = nid

--- a/lcapy/schematic.py
+++ b/lcapy/schematic.py
@@ -550,32 +550,36 @@ class Schematic(NetfileMixin):
         Note, if using Jupyter, then need to first issue command %matplotlib inline
 
         kwargs include:
-           'label_ids': True to show component ids
-           'label_values': True to display component values
-           "label_value_style': 'eng' for engineering (SI); 'sci' for scientific;
-                                'ratfun' for rational function; 'spice' for SPICE"
-           'label_flip': Place label on other side of component
-           'annotate_values': True to display component values as separate label
-           'draw_nodes': True to show all nodes,
-             False or 'none' to show no nodes,
-             'primary' to show primary nodes,
-             'connections' to show nodes that connect more than two components,
-             'all' to show all nodes
-           'label_nodes': True to label all nodes,
-             False or 'none' to label no nodes,
-             'primary' to label primary nodes (nodes without an underscore),
-             'alpha' to label nodes starting with a letter,
-             'pins' to label nodes that are pins on a chip,
-             'all' to label all nodes,
-           'anchor': where to position node label (default south east)
-           'include': name of file to include before \\begin{document}
-           'style': 'american', 'british', or 'european'
-           'scale': schematic scale factor, default 1.0
-           'node_spacing': spacing between component nodes, default 2.0
-           'cpt_size': size of a component, default 1.5
-           'dpi': dots per inch for png files, default 300
-           'help_lines': distance between lines in grid, default 0 (disabled)
-           'debug': non-zero to display debug information
+            'label_ids': True to show component ids
+            'label_values': True to display component values
+            "label_value_style':
+                'eng' for engineering (SI); 'sci' for scientific;
+                'ratfun' for rational function; 'spice' for SPICE"
+            'label_flip': Place label on other side of component
+            'annotate_values': True to display component values as separate
+            label
+            'draw_nodes':
+                True to show all nodes,
+                False or 'none' to show no nodes,
+                'primary' to show primary nodes,
+                'connections' to show nodes that connect more than two components,
+                'all' to show all nodes
+            'label_nodes':
+                True to label all nodes,
+                False or 'none' to label no nodes,
+                'primary' to label primary nodes (nodes without an underscore),
+                'alpha' to label nodes starting with a letter,
+                'pins' to label nodes that are pins on a chip,
+                'all' to label all nodes,
+            'anchor': where to position node label (default south east)
+            'include': name of file to include before \\begin{document}
+            'style': 'american', 'british', or 'european'
+            'scale': schematic scale factor, default 1.0
+            'node_spacing': spacing between component nodes, default 2.0
+            'cpt_size': size of a component, default 1.5
+            'dpi': dots per inch for png files, default 300
+            'help_lines': distance between lines in grid, default 0 (disabled)
+            'debug': non-zero to display debug information
         """
 
         # None means don't care, so remove.  Use list so can remove

--- a/lcapy/schemcpts.py
+++ b/lcapy/schemcpts.py
@@ -381,10 +381,11 @@ class SP(FixedCpt):
 
     @property
     def pins(self):
+        """Return the pin names for the current node"""
         return self.mirror_pins if self.mirror else self.normal_pins
 
     def draw(self, **kwargs):
-
+        """Draw the summing point"""
         if not self.check():
             return ''
 
@@ -424,6 +425,7 @@ class SP3(SP):
 
     @property
     def pins(self):
+        """Return the pin names for the current node"""
         return self.mirror_pins if self.mirror else self.normal_pins
 
 
@@ -758,11 +760,12 @@ class SPDT(FixedCpt):
 
     @property
     def pins(self):
+        """Return the pin names for the current node"""
         # The mirror pins are at the same locations as the normal pins
         return self.invert_pins if self.invert else self.normal_pins
 
     def draw(self, **kwargs):
-
+        """Draw the switch"""
         if not self.check():
             return ''
 

--- a/lcapy/sexpr.py
+++ b/lcapy/sexpr.py
@@ -469,13 +469,14 @@ class LaplaceDomainExpression(LaplaceDomain, Expr):
                               normalize_a0=True):
         """Create differential equation from transfer function.
 
-        For example,
-        >>> H = (s + 3) / (s**2 + 4)
-        >>> H.differential_equation()
-               d                    d
-        y(t) + --(y(t)) = 4.x(t) + ---(x(t))
-               dt                    2
-                                     dt
+        For example::
+            >>> H = (s + 3) / (s**2 + 4)
+            >>> H.differential_equation()
+            ::
+                       d                    d
+                y(t) + --(y(t)) = 4.x(t) + ---(x(t))
+                       dt                    2
+                                             dt
         """
 
         fil = self.lti_filter(normalize_a0)

--- a/lcapy/superposition.py
+++ b/lcapy/superposition.py
@@ -305,7 +305,7 @@ class Superposition(SuperpositionDomain, ExprDict):
         return call(self, arg, **assumptions)
 
     def subs(self, *args, **kwargs):
-
+        """ Substitute values into all components of the superposition."""
         new = self.__class__()
         for kind, value in self.items():
             new[kind] = value.subs(*args, **kwargs)


### PR DESCRIPTION
The sphinx build is failing with an indentation error and aborting. The same errors are occuring in the docs test, but the github runner does not abort on error, whereas RTD does by default. 

I have swatted the errors reported in the github runner's docs test (some indentation inconsistency, some missing docstrings confusing the parser), and added some apt packages and pre-install arguments to conf.py to get as close to the environment in the github runner as possible using RTDs build settings. 

The current "stable" branch was indeed failing due to the missing [doc] specifier, so we're getting incrementally closer to live docs.