### PR TITLE
fix: patch sphinx autodoc's methodimporter to screen for properties.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -255,3 +255,27 @@ autosummary_generate = True  # Turn on sphinx.ext.autosummary
 #   by lcapy.oneport.v, rename lcapy.oneport.v.html to lcapy.oneport.v_t-domain.html
 autosummary_filename_map = {'lcapy.oneport.v':'lcapy.oneport.v_t-domain',
                             'lcapy.oneport.i':'lcapy.oneport.i_t-domain',}
+
+# Patch autosummary.get_documenter to handle identically_named properties
+# without error
+try:
+    from sphinx.ext.autosummary import get_documenter as _orig_get_documenter
+    from sphinx.ext import autosummary as _as_mod
+    from sphinx.ext.autodoc import AttributeDocumenter as _AttrDoc
+except Exception:
+    _orig_get_documenter = None
+
+if _orig_get_documenter and not getattr(_as_mod, '_lcapy_get_documenter_patch', False):
+    def _lcapy_get_documenter(app, obj, parent):
+        try:
+            if isinstance(obj, property):
+                return _AttrDoc
+            if isinstance(parent, property):
+                parent = None  # Avoid AttributeError paths
+        except Exception:
+            pass
+        return _orig_get_documenter(app, obj, parent)
+
+    _as_mod.get_documenter = _lcapy_get_documenter
+    _as_mod._lcapy_get_documenter_patch = True
+

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='lcapy',
       python_requires='>=3.7',  # >=3.6 should still work but not tested
       extras_require={
           'test': tests_require,
-          'doc': ['sphinx>=7', 'ipython', 'sphinx-rtd-theme', 'docutils',
+          'doc': ['sphinx==8.1.3', 'ipython', 'sphinx-rtd-theme', 'docutils',
                   'pygments'],
           'release': ['wheel', 'twine'],
       },


### PR DESCRIPTION
The error that readthedocs is facing when building using Sphinx is caused by
oneport.G having an identically named property G.G. I'm not sure exactly why 
the identical name causes the error, but it ends up trying to document G.G 
as a method instead of a property, and calling G.G.__dict__(), 
which throws the error. I had a look at patching sphinx, but that portion of 
the code has been refactored in the dev version, which fails for other reasons
when installed from source, so I've made a monkeypatch in conf.py. This 
patch is only compatible with sphinx < 8.2, so I've pinned the dependency to 
8.1.3 in setup.py and have verified that this builds on my machine (after verifying that I hit the same error before patching!)
    
How your CI environment manages to get around this is a mystery to me. It 
looks like when you install xvfb it drags along many python packages at an 
OS level, which might somehow make it compatible? Unverified speculation.